### PR TITLE
feat: modernize frontend style

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,7 +8,7 @@ import AccompanimentControls from "./components/AccompanimentControls";
 export default function App() {
   return (
     <div className="container vstack">
-      <h1 style={{fontSize:28, marginBottom:4}}>🎻 Violin AI — tuner, nuty i akompaniament</h1>
+      <h1>🎻 Violin AI — tuner, nuty i akompaniament</h1>
       <span className="badge">alpha starter</span>
       <div className="grid">
         <div className="vstack">

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -1,14 +1,18 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap');
 
 :root {
-  --bg: #0b1020;
-  --fg: #e9eefc;
-  --card-bg: #121a35;
-  --card-border: #21305c;
-  --surface: #1a2447;
-  --surface-hover: #223060;
-  --accent: #31467f;
-  --radius: 14px;
+  --bg: #f8fafc;
+  --fg: #1f2937;
+  --surface: #ffffff;
+  --surface-hover: #f1f5f9;
+  --accent: #3b82f6;
+  --radius: 12px;
+  --shadow: 0 4px 20px rgba(0, 0, 0, 0.05);
+}
+
+html,
+body {
+  height: 100%;
 }
 
 body {
@@ -20,17 +24,19 @@ body {
 }
 
 .container {
-  max-width: 1100px;
-  margin: 24px auto;
-  padding: 0 16px;
+  width: 100%;
+  max-width: none;
+  margin: 0;
+  padding: 32px;
+  box-sizing: border-box;
 }
 
 .card {
-  background: var(--card-bg);
-  border: 1px solid var(--card-border);
+  background: var(--surface);
+  border: 1px solid #e2e8f0;
   border-radius: var(--radius);
   padding: 16px;
-  box-shadow: 0 8px 24px rgba(0,0,0,.2);
+  box-shadow: var(--shadow);
 }
 
 .hstack {
@@ -46,8 +52,8 @@ body {
 }
 
 h1 {
-  font-size: 22px;
-  margin: 0 0 6px 0;
+  font-size: 32px;
+  margin: 0 0 12px 0;
 }
 
 label {
@@ -55,33 +61,37 @@ label {
   opacity: .85;
 }
 
-button, select, input[type="file"] {
+button,
+select,
+input[type="file"] {
   background: var(--surface);
   color: var(--fg);
-  border: 1px solid #344a86;
-  border-radius: 10px;
-  padding: 8px 12px;
+  border: 1px solid #cbd5e1;
+  border-radius: var(--radius);
+  padding: 10px 14px;
   cursor: pointer;
-  transition: background .2s ease;
+  transition: background .2s ease, box-shadow .2s ease;
 }
 
 button:hover,
 select:hover {
   background: var(--surface-hover);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
 }
 
 .badge {
   font-size: 12px;
   padding: 3px 8px;
-  background: #1d2a54;
+  background: var(--accent);
+  color: #fff;
   border-radius: 999px;
-  border: 1px solid var(--accent);
+  border: none;
 }
 
 .grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 16px;
+  gap: 24px;
 }
 
 @media (max-width: 768px) {
@@ -96,6 +106,7 @@ select:hover {
 
 hr {
   border: none;
-  border-top: 1px solid #223060;
+  border-top: 1px solid #e2e8f0;
   margin: 8px 0;
 }
+


### PR DESCRIPTION
## Summary
- refresh main stylesheet with light theme and full-width layout
- clean up heading to use new global styles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689de75e684483239b6afb0f12643cfd