### PR TITLE
feat: modernize app styling

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,3 +1,4 @@
+import "./styles/reset.css";
 import "./styles/main.css"; // ⬅️ styles z folderu src/styles
 import { useState } from "react";
 import PracticeTab from "./components/PracticeTab";

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -25,8 +25,8 @@ body {
 
 .container {
   width: 100%;
-  max-width: none;
-  margin: 0;
+  max-width: 1024px;
+  margin: 0 auto;
   padding: 32px;
   box-sizing: border-box;
 }
@@ -70,13 +70,48 @@ input[type="file"] {
   border-radius: var(--radius);
   padding: 10px 14px;
   cursor: pointer;
-  transition: background .2s ease, box-shadow .2s ease;
+  transition: background .2s ease, box-shadow .2s ease, color .2s ease;
 }
 
 button:hover,
 select:hover {
   background: var(--surface-hover);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+}
+
+button:focus,
+select:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.4);
+}
+
+.tabs {
+  display: flex;
+  background: var(--surface);
+  border: 1px solid #e2e8f0;
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+.tabs button {
+  flex: 1;
+  border: none;
+  background: transparent;
+  padding: 10px 16px;
+  transition: background .2s ease, color .2s ease;
+}
+
+.tabs button:not(:last-child) {
+  border-right: 1px solid #e2e8f0;
+}
+
+.tabs button.active {
+  background: var(--accent);
+  color: #fff;
+}
+
+.tabs button:hover:not(.active) {
+  background: var(--surface-hover);
 }
 
 .badge {


### PR DESCRIPTION
## Summary
- apply CSS reset and import it into App
- center container and add focus + tab styles for a cleaner, modern UI

## Testing
- `node node_modules/vite/bin/vite.js build`


------
https://chatgpt.com/codex/tasks/task_e_689e24fc9f9883239ff050b369dafc1e